### PR TITLE
タスク新規投稿の保存可否で処理を分ける。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,9 @@ group :test do
   gem "selenium-webdriver"
 
 end
+
+gem 'pry-rails'
+
+
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -128,6 +129,11 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
@@ -190,7 +196,7 @@ GEM
     stringio (3.0.8)
     thor (1.2.2)
     timeout (0.4.0)
-    turbo-rails (1.4.0)
+    turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -218,6 +224,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8)
   selenium-webdriver

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   def index
+    
   end
 
   def new
@@ -7,9 +8,16 @@ class TasksController < ApplicationController
   end
   
   def create
-    task = Task.new(title: params[:title], detail: params[:detail])
-    task.save
-    redirect_to "/"
+    @task = Task.new(title: params[:title], detail: params[:detail])
+      if @task.save
+        flash[:notice] = "タスク作成に成功しました"
+        redirect_to "/"
+      else
+        flash[:error] = @task.errors.full_messages
+        render :new, status: :unprocessable_entity
+        #HTTPのレスポンスステータスコードを422（Unprocessable Entity）に設定するオプションです。
+        #これは、リクエストがバリデーションエラーやクライアント側の問題などの理由で処理できない場合を示します。
+      end
   end
 
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,5 @@
 class Task < ApplicationRecord
+  validates :title, :detail, presence: true
+
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,25 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <%# <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%# <%= javascript_include_tag 'application' %>
   </head>
 
   <body>
+
+
+<% flash.each do |key, value| %>
+    <p class="alert alert-<%= key %>">
+      <%= value %>
+    </p>
+<% end %>
+
+
+
+
+
+    
     <%= yield %>
   </body>
 </html>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,3 +1,6 @@
+
+<%= link_to "新規投稿", tasks_new_path %>
+
 <h1>Todoapp</h1>
 
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,7 @@
 
+
+<%= link_to "トップページ", root_path %>
+
 <h2>新規投稿</h2>
 
 <%= form_with url: tasks_create_path do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   get "/" => "tasks#index"
-  root to:  "tasks#index"
+  root :to =>  "tasks#index"
   get "tasks/new" => "tasks#new"
   post "tasks/create" => "tasks#create"
+  
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 変更の概要
保存可否で処理を分けた。

## なぜこの変更をするのか
* 空欄で投稿するタスクはないと考えるため。
* 投稿可否の結果をメッセージ付きで表示することで、ユーザーが使いやすくするため。

## やったこと
* やったこと
*モデルに空欄禁止のバリデーションを設定した。
* createアクション内で保存可否の条件で処理を分けた。（投稿成功・失敗した時にメッセージを表示する）
* トップページに新規投稿ページのリンクを追加。
* 新規投稿ページにトップページのリンクを追加。

* やっていないこと
* CSSには変更を加えていません。

## 変更内容
* UIの変更ならスクリーンショット
https://github.com/gaburieru123/todoapp7/assets/69755688/fe147c6a-3a7f-4ade-874e-8a37dcb204a7

## 影響範囲
* ユーザーに影響すること：空欄では登録できないようになっている。
* メンバーに影響すること：今の所なし
* システムに影響すること：空欄では登録できないようになっている。

## どうやるのか
* 使い方
* 新規投稿ページのタイトルと詳細の蘭に入力して「SAVE」ボタンを押すとトップページへ画面遷移して、成功時のメッセージが表示される。
* 新規投稿ページのタイトルと詳細の蘭どちらかを空欄のまま「SAVE」ボタンを押すと新規投稿ページへ画面遷移して、保存失敗時のメッセージが表示される。

## 課題
* とくにレビューしてほしいところ
* createアクションのrenderメソッドで画面遷移する方法として、status: :unprocessable_entityを使用したが、他の方法があれば教えて欲しいです。（statusオプションがないと画面遷移しません。）



