### PR TITLE
編集画面と更新機能を作成。トップページと詳細ページから編集画面へ移動できるようにした。

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,5 +24,25 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
+  def edit
+    @task = Task.find_by(id: params[:id])
+  end
+
+
+  def update
+    @task = Task.find_by(id: params[:id])
+    @task.title = params[:title]
+    @task.detail = params[:detail]
+
+    if @task.save
+      flash[:notice] = "タスク更新に成功しました"
+      redirect_to "/"
+    else
+      flash[:error] = @task.errors.full_messages
+      redirect_to "/tasks/edit/#{@task.id}"
+      #画面遷移した時に初期値（前の入力内容）を入れておきたいので、redirect_toで画面遷移している。
+    end    
+  end
+
 
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,17 @@
+<%= link_to "トップページ", root_path %>
+<%= link_to "新規投稿", tasks_new_path %>
+
+<h3>編集</h3>
+
+
+<%= form_with url: "/tasks/update/#{@task.id}" do |f| %>
+  <p>タイトル</p>
+  <%= f.text_field :title, value: @task.title %></br>
+
+  <p>詳細</p>
+  <textarea name="detail" cols="50" rows="10"><%= @task.detail %></textarea>
+  <%# @task.detailで初期値を入れいている %>
+  <%# nameにdetailを設定することで、更新する内容をパラメーターとして渡すようにしている %>
+  <%#<%= f.text_area :detail, size: "50x10" %></br>
+  <%= f.submit '更新' %>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -8,7 +8,9 @@
 <% @tasks.each do |task| %>
 <li>
 <%= link_to "#{task.title}", tasks_show_id_path(task) %><br>
-
+<%= link_to "詳細", tasks_show_id_path(task) %>
+<%# 上２つのリンクはどちらも詳細ページへリンクするようにしている %>
+<%= link_to "編集", "/tasks/edit/#{task.id}" %>
 </li>
 <%# <h3>詳細</h3> %>
 <%# <%= task.detail %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,5 +9,6 @@
 
 <p>詳細</p>
 <%= @task.detail %><br>
+<%= link_to "編集", "/tasks/edit/#{@task.id}" %>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get "tasks/new" => "tasks#new"
   post "tasks/create" => "tasks#create"
   get "tasks/show/:id" => "tasks#show", as: 'tasks_show_id' #asでprefix名（tasks_show_id）をつけている。
+  get "tasks/edit/:id" => "tasks#edit"
+  post "tasks/update/:id" => "tasks#update"
   
 
 


### PR DESCRIPTION
## 変更の概要
* 編集画面を作成し、タスク更新できるようにした。

## なぜこの変更をするのか
* 変更をする理由
タスク内容が変わった時のために更新できるようにした。


## やったこと
* [x] やったこと
アップデート可否で保存条件を分け、保存不可の画面遷移時にあらかじめ入力されていた内容も表示するようにした。
トップページと詳細ページどちらからも編集画面へ移動できる。
* [ ] やっていないこと
CSSの変更はしていません。

## 変更内容
動画
https://github.com/gaburieru123/todoapp7/assets/69755688/01f59f60-7a01-4744-bbb2-c3e2218b2786
https://github.com/gaburieru123/todoapp7/assets/69755688/94b8b9d0-de9d-4689-a602-4912a49da688

## 影響範囲
* ユーザーに影響すること：更新ができるようになる。
* メンバーに影響すること：特になし
* システムに影響すること：特になし

## どうやるのか
* 使い方
編集ボタンをクリックしてフォームを変更して更新ボタンを押す。

## 課題
* 悩んでいること
トップページの詳細ボタン不要ですか。
というのも、トップページのタイトルをクリックしてもでも詳細ページに移動できます。
詳細ボタンがあってもわかりやすくていいかなと思ったので詳細ボタンも追加しています。
* とくにレビューしてほしいところ
edit.html.erbでform_with内のtext_areaをHTMLの<textarea></textarea>を使用しています。
それは、初期値を入れるオプションがないと考えているからです。
上記の考え方であっていますか。

## 備考
* その他に伝えたいこ：特になし