### PR TITLE
ログインユーザーの登録タスクのみトップページへ表示する。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,9 @@ group :test do
 
 end
 
-gem 'pry-rails'
 gem 'devise'
 
+gem 'debug'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -137,11 +136,6 @@ GEM
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
@@ -238,7 +232,6 @@ DEPENDENCIES
   devise
   importmap-rails
   jbuilder
-  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8)
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+    #ログアウトした時のパスをログイン画面にするように設定。
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,12 @@
 class TasksController < ApplicationController
+  before_action :authenticate_user!, except: [:new]
+  # ログインしていない場合、ログイン画面に移動する
+  before_action :correct_task,only: [:create, :show, :edit, :update]
+  # URLに直打ちした時にトップページやログイン画面へ移動する。
+  
   def index
-    @tasks = Task.all
+    @tasks = Task.where(user_id: current_user.id)
+    # トップページに表示するタスクを自分のタスクのみに設定
   end
 
   def new
@@ -50,6 +56,20 @@ class TasksController < ApplicationController
     task.destroy
     flash[:notice] = "タスク削除に成功しました"
     redirect_to "/"
+  end
+
+
+  private
+
+  def correct_task
+    @task = Task.find_by(id:params[:id])
+    if @task == nil
+      redirect_to "/"
+      # @taskのidがURL直打ちした時にnilならトップページへ移動
+    elsif @task.user_id != current_user.id
+      redirect_to new_user_session_path
+      # @taskとログインユーザーidが異なっていたら、ログイン画面へ移動
+    end
   end
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,15 +9,12 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
 
-    <%# <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%# <%= javascript_include_tag 'application' %>
   </head>
 
   <body>
     <% if user_signed_in? %>
       <header>
         <%= current_user.name %>
-        <div><%= link_to "トップ", root_path, class: "text-white" %></div>
         <div><%= link_to root_path do %><img src="/assets/header.png" alt="logo" id="logo" width="100" height="100"><% end %></div>
         <div><%= link_to "トップ", root_path, class: "text-white" %></div>
         <div><%= link_to "投稿する", tasks_new_path, class: "text-white" %></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users 
   get "/" => "tasks#index"
+  get "tasks/index" => "tasks#index"
   root :to =>  "tasks#index"
   get "tasks/new" => "tasks#new"
   post "tasks/create" => "tasks#create"


### PR DESCRIPTION
## 変更の概要
* ログインユーザーの登録タスクのみトップページへ表示する。


## なぜこの変更をするのか
* 他のユーザーのタスクやユーザーモデル作成する前に作ったタスクも表示されていたため。

## やったこと
* [x] やったこと
*tasksコントローラーのindexアクションでwhereメソッドを使用し、user_id（外部キー）カラムがログインユーザーのidのタスクのみ取得した。
*ログインしていないユーザーで登録の操作などできないように設定した。（before_actionでアクションごとに画面切り替え。）
*gemfileでdebug gem追加、pry-rails gemアンインストールした。
* [ ] やっていないこと
CSSの設定はしていません。

## 変更内容
<img width="305" alt="image" src="https://github.com/gaburieru123/todoapp7/assets/69755688/07b39c8b-cf27-42c8-aac3-3a13ad0bcfd3">

* <img width="576" alt="image" src="https://github.com/gaburieru123/todoapp7/assets/69755688/710b7e94-6d30-44cc-8718-200f9c7fd62c">

<img width="410" alt="image" src="https://github.com/gaburieru123/todoapp7/assets/69755688/57e5bdd7-4a4e-47ac-be3e-4a77e713c6ec">

<img width="522" alt="image" src="https://github.com/gaburieru123/todoapp7/assets/69755688/ff57fb26-1783-4567-b8bd-d1d460e4e93e">

## 影響範囲
* ユーザーに影響すること；自分のタスクのみ表示される。他のユーザーのタスク編集できない。
* メンバーに影響すること：特になし
* システムに影響すること：特になし

## どうやるのか
* ログインしてトップページに移動する。

## 課題
* 悩んでいること：特になし
* とくにレビューしてほしいところ：特になし

## 備考
* その他に伝えたいこと：特になし