### PR TITLE
ユーザー削除の条件にuserのidとログインユーザーのidが同じな時に削除できる設定に修正した。

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,14 @@ class UsersController < ApplicationController
 
   def destroy
     user = User.find(params[:id])
-    user.destroy
-    flash[:notice] = "アカウント削除に成功しました"
-    redirect_to new_user_registration_path
+    binding.b
+    if user.id == current_user.id && user.destroy
+      flash[:notice] = "アカウント削除に成功しました"
+      redirect_to new_user_registration_path
+    else
+      flash[:notice] = "無効な操作です。アカウント削除はできません。"
+      redirect_to user_path
+    end
   end
 
 end


### PR DESCRIPTION
## 変更の概要
* 現在のユーザーとログインユーザーが同じ時にアカウント削除できるように設定した。

## なぜこの変更をするのか
* 異なるユーザーのアカウント削除をしないように。

## やったこと
* [x] やったこと
*destroyアクションにif文でuser.id == current_user.idが真の時にアカウント削除できるようにした。
* [ ] やっていないこと
CSSの設定はしていません。

## 影響範囲
* ユーザーに影響すること：異なるユーザーのアカウント削除できないし、されない
* メンバーに影響すること：特になし
* システムに影響すること：特になし

## どうやるのか
* 使い方：アカウント削除ボタン押す

## 課題
* 悩んでいること：特になし
* とくにレビューしてほしいところ：特になし

## 備考
* その他に伝えたいこと：特になし